### PR TITLE
Fix crash when first message exceeds max token length.

### DIFF
--- a/Sources/ChatGPTSwift/ChatGPTAPI.swift
+++ b/Sources/ChatGPTSwift/ChatGPTAPI.swift
@@ -57,7 +57,9 @@ public class ChatGPTAPI: @unchecked Sendable {
     private func generateMessages(from text: String, systemText: String) -> [Message] {
         var messages = [systemMessage(content: systemText)] + historyList + [Message(role: "user", content: text)]
         if gptEncoder.encode(text: messages.content).count > 4096  {
+            if !historyList.isEmpty() {
             _ = historyList.removeFirst()
+            }
             messages = generateMessages(from: text, systemText: systemText)
         }
         return messages


### PR DESCRIPTION
When the first message is sent there are no entries in the historyList. If the token length exceeds 4096, it would cause a crash due to `.removeFirst()` being called on the empty list.