### PR TITLE
Added Support for GPT-4o ("Omni") Models

### DIFF
--- a/Sources/ChatGPTSwift/GeneratedSources/Types.swift
+++ b/Sources/ChatGPTSwift/GeneratedSources/Types.swift
@@ -2858,6 +2858,8 @@ public enum Components {
                 public var value1: Swift.String?
                 /// - Remark: Generated from `#/components/schemas/CreateChatCompletionRequest/model/value2`.
                 @frozen public enum Value2Payload: String, Codable, Hashable, Sendable {
+                    case gpt_hyphen_4o_mini = "gpt-4o-mini"
+                    case gpt_hyphen_4o_hyphen_mini_hyphen_2024_hyphen_07_hyphen_18 = "gpt-4o-mini-2024-07-18"
                     case gpt_hyphen_4o = "gpt-4o"
                     case gpt_hyphen_4o_hyphen_2024_hyphen_05_hyphen_13 = "gpt-4o-2024-05-13"
                     case gpt_hyphen_4_hyphen_turbo = "gpt-4-turbo"


### PR DESCRIPTION
OpenAI's latest GPT-4o (o for "Omni") models are now added to the ChatGPTModel enum.

This is now up to date with https://platform.openai.com/docs/models as of 27.08.24