### PR TITLE
Support custom ClientTransport, support image detail with message image input

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "11205411bb60612f0a1a04f733fa71b4fb864ab9",
-        "version" : "1.22.1"
+        "revision" : "fb308ee72f3d4c082a507033f94afa7395963ef3",
+        "version" : "1.21.0"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "9746cf80e29edfef2a39924a66731249223f42a3",
-        "version" : "2.72.0"
+        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
+        "version" : "2.64.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d1ead62745cc3269e482f1c51f27608057174379",
-        "version" : "1.24.0"
+        "revision" : "a3b640d7dc567225db7c94386a6e71aded1bfa63",
+        "version" : "1.22.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b5f7062b60e4add1e8c343ba4eb8da2e324b3a94",
-        "version" : "1.34.0"
+        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
+        "version" : "1.30.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "7b84abbdcef69cc3be6573ac12440220789dcd69",
-        "version" : "2.27.2"
+        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
+        "version" : "2.26.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
-        "version" : "1.21.0"
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "fb308ee72f3d4c082a507033f94afa7395963ef3",
-        "version" : "1.21.0"
+        "revision" : "11205411bb60612f0a1a04f733fa71b4fb864ab9",
+        "version" : "1.22.1"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
+      "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
-        "version" : "2.64.0"
+        "revision" : "9746cf80e29edfef2a39924a66731249223f42a3",
+        "version" : "2.72.0"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a3b640d7dc567225db7c94386a6e71aded1bfa63",
-        "version" : "1.22.0"
+        "revision" : "d1ead62745cc3269e482f1c51f27608057174379",
+        "version" : "1.24.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
-        "version" : "1.30.0"
+        "revision" : "b5f7062b60e4add1e8c343ba4eb8da2e324b3a94",
+        "version" : "1.34.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
-        "version" : "2.26.0"
+        "revision" : "7b84abbdcef69cc3be6573ac12440220789dcd69",
+        "version" : "2.27.2"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
-        "version" : "1.20.1"
+        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
+        "version" : "1.21.0"
       }
     },
     {

--- a/Sources/ChatGPTSwift/ChatGPTAPI.swift
+++ b/Sources/ChatGPTSwift/ChatGPTAPI.swift
@@ -97,10 +97,10 @@ public class ChatGPTAPI: @unchecked Sendable {
                                   maxTokens: Int? = nil,
                                   responseFormat: Components.Schemas.CreateChatCompletionRequest.response_formatPayload? = nil,
                                   stop: Components.Schemas.CreateChatCompletionRequest.stopPayload? = nil,
-                                  imageData: Data? = nil) async throws -> AsyncMapSequence<AsyncThrowingPrefixWhileSequence<AsyncThrowingMapSequence<ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<HTTPBody>>, ServerSentEventWithJSONData<Components.Schemas.CreateChatCompletionStreamResponse>>>, String> {
+                                  imageInput: ImageInput? = nil) async throws -> AsyncMapSequence<AsyncThrowingPrefixWhileSequence<AsyncThrowingMapSequence<ServerSentEventsDeserializationSequence<ServerSentEventsLineDeserializationSequence<HTTPBody>>, ServerSentEventWithJSONData<Components.Schemas.CreateChatCompletionStreamResponse>>>, String> {
         var messages = generateInternalMessages(from: text, systemText: systemText)
-        if let imageData {
-            messages.append(createMessage(imageData: imageData))
+        if let imageInput {
+            messages.append(createMessage(imageData: imageInput.data, detail: imageInput.detail))
         }
         
         let response = try await client.createChatCompletion(.init(headers: .init(accept: [.init(contentType: .text_event_hyphen_stream)]), body: .json(.init(
@@ -147,10 +147,10 @@ public class ChatGPTAPI: @unchecked Sendable {
                             maxTokens: Int? = nil,
                             responseFormat: Components.Schemas.CreateChatCompletionRequest.response_formatPayload? = nil,
                             stop: Components.Schemas.CreateChatCompletionRequest.stopPayload? = nil,
-                            imageData: Data? = nil) async throws -> String {
+                            imageInput: ImageInput? = nil) async throws -> String {
         var messages = generateInternalMessages(from: text, systemText: systemText)
-        if let imageData {
-            messages.append(createMessage(imageData: imageData))
+        if let imageInput {
+            messages.append(createMessage(imageData: imageInput.data, detail: imageInput.detail))
         }
         
         let response = try await client.createChatCompletion(body: .json(.init(
@@ -185,7 +185,7 @@ public class ChatGPTAPI: @unchecked Sendable {
     ) async throws -> ChatCompletionResponseMessage {
         var messages = generateInternalMessages(from: prompt, systemText: systemText)
         if let imageData {
-            messages.append(createMessage(imageData: imageData))
+            messages.append(createMessage(imageData: imageData, detail: .auto))
         }
         
         let response = try await client.createChatCompletion(.init(body: .json(.init(
@@ -333,13 +333,14 @@ public class ChatGPTAPI: @unchecked Sendable {
     }
     
     
-    func createMessage(imageData: Data) -> Components.Schemas.ChatCompletionRequestMessage {
+    func createMessage(imageData: Data,
+                       detail: Components.Schemas.ChatCompletionRequestMessageContentPartImage.image_urlPayload.detailPayload) -> Components.Schemas.ChatCompletionRequestMessage {
         .ChatCompletionRequestUserMessage(
             .init(content: .case2([.ChatCompletionRequestMessageContentPartImage(
                 .init(_type: .image_url,
                       image_url:
                         .init(url: "data:image/jpeg;base64,\(imageData.base64EncodedString())",
-                        detail: .auto)))]),
+                        detail: detail)))]),
                   role: .user))
     }
     

--- a/Sources/ChatGPTSwift/ChatGPTAPI.swift
+++ b/Sources/ChatGPTSwift/ChatGPTAPI.swift
@@ -54,6 +54,13 @@ public class ChatGPTAPI: @unchecked Sendable {
             middlewares: [AuthMiddleware(apiKey: apiKey)])
     }
     
+    public init(apiKey: String, clientTransport: ClientTransport) {
+        self.apiKey = apiKey
+        self.client = Client(serverURL: URL(string: self.urlString)!,
+            transport: clientTransport,
+            middlewares: [AuthMiddleware(apiKey: apiKey)])
+    }
+    
     private func generateMessages(from text: String, systemText: String) -> [Message] {
         var messages = [systemMessage(content: systemText)] + historyList + [Message(role: "user", content: text)]
         if gptEncoder.encode(text: messages.content).count > 4096  {

--- a/Sources/ChatGPTSwift/Models.swift
+++ b/Sources/ChatGPTSwift/Models.swift
@@ -17,6 +17,16 @@ public struct Message: Codable {
     }
 }
 
+public struct ImageInput {
+    let data: Data
+    let detail: Components.Schemas.ChatCompletionRequestMessageContentPartImage.image_urlPayload.detailPayload
+    
+    public init(data: Data, detail: Components.Schemas.ChatCompletionRequestMessageContentPartImage.image_urlPayload.detailPayload = .auto) {
+        self.data = data
+        self.detail = detail
+    }
+}
+
 extension Array where Element == Message {
     
     var contentCount: Int { map { $0.content }.count }


### PR DESCRIPTION
* Support a custom `ClientTransport` in a new `ChatGPTAPI` initializer for extra client control, e.g. using a custom `URLSession` with `URLSessionTransport`.
* Support image detail for vision requests